### PR TITLE
Smoother rendering

### DIFF
--- a/OpenRealSense.Cmd/Program.cs
+++ b/OpenRealSense.Cmd/Program.cs
@@ -55,7 +55,8 @@ namespace OpenRealSense.Cmd {
                             }
                         }
                         buffer[bufferIndex] = ' ';
-                        Console.WriteLine();
+                        Console.CursorLeft = 0;
+                        Console.CursorTop = 0;
                         Console.Write(buffer);
                     }
                 }

--- a/OpenRealSense.Cmd/Program.cs
+++ b/OpenRealSense.Cmd/Program.cs
@@ -33,6 +33,7 @@ namespace OpenRealSense.Cmd {
 
             device.EnableStream(StreamType.Depth, width, height, FormatType.Z16, 30);
             device.StartInBackground(() => {
+                Console.CursorVisible = false;
                 var frameInBytes = device.GetFrameData(StreamType.Depth).Bytes;
                 using (var stream = new MemoryStream(frameInBytes)) {
                     using (var reader = new BinaryReader(stream)) {
@@ -62,6 +63,7 @@ namespace OpenRealSense.Cmd {
                 }
             });
             Console.ReadLine();
+            Console.CursorVisible = true;
             device.Stop();
         }
     }


### PR DESCRIPTION
Changed from rendering output as a waterfall to rendering it as a video.
The cursor is hidden and every frame is rendered from (0, 0), overriding the previous frame.